### PR TITLE
Conform Menu Navigation to Transient Conventions

### DIFF
--- a/lisp/casual-info-settings.el
+++ b/lisp/casual-info-settings.el
@@ -54,9 +54,10 @@
                     "Prefer subnodes when scrolling")))]
 
   [:class transient-row
+          (casual-info-quit-one)
           ("a" "About" casual-info-about :transient nil)
           ("v" "Version" casual-info-version :transient nil)
-          ("q" "Dismiss" ignore :transient transient--do-exit)])
+          (casual-info-quit-all)])
 
 ;;; Functions
 

--- a/lisp/casual-info-utils.el
+++ b/lisp/casual-info-utils.el
@@ -96,5 +96,23 @@ V is either nil or non-nil."
       (format " %s" buf)
     buf))
 
+;; Transient Navigation
+(transient-define-suffix casual-info-quit-all ()
+  "Dismiss all menus."
+  :transient nil
+  :key "C-q"
+  :description "Dismiss"
+  (interactive)
+  (transient-quit-all))
+
+(transient-define-suffix casual-info-quit-one ()
+  "Go back to previous menu."
+  :transient nil
+  :key "C-g"
+  :description "‹Back"
+  (interactive)
+  (transient-quit-one))
+
+
 (provide 'casual-info-utils)
 ;;; casual-info-utils.el ends here

--- a/lisp/casual-info.el
+++ b/lisp/casual-info.el
@@ -140,14 +140,13 @@
                     (casual-info-unicode-db-get :fast-forward-or-down))
            :transient t)
           ("," "Settings›" casual-info-settings-tmenu)
-          ("q" "Dismiss" ignore :transient transient--do-exit)])
-
+          (casual-info-quit-all)
+          ("q" "Quit Info" quit-window)])
 
 (defun casual-info-clone-frame ()
   "Clone frame."
   (interactive)
   (clone-frame nil t))
-
 
 (provide 'casual-info)
 ;;; casual-info.el ends here


### PR DESCRIPTION
- Change menu navigation to conform to Transient conventions.
  - Binding C-g "‹Back" invokes transient-quit-one
  - Binding C-q "Dismiss" invokes transient-quit-all

- Redefine binding q to invoke quit-window
